### PR TITLE
[POC] add refreshtoken to extend accessToken

### DIFF
--- a/packages/shopping/src/application.ts
+++ b/packages/shopping/src/application.ts
@@ -23,8 +23,10 @@ import {
   UserServiceBindings,
   TokenServiceConstants,
   PasswordHasherBindings,
+  RefreshtokenServiceBindings,
 } from './keys';
 import {JWTService} from './services/jwt-service';
+import {MyRefreshtokenService} from './services/refreshtoken.service';
 import {MyUserService} from './services/user-service';
 import _ from 'lodash';
 import path from 'path';
@@ -132,6 +134,9 @@ export class ShoppingApplication extends BootMixin(
     );
 
     this.bind(TokenServiceBindings.TOKEN_SERVICE).toClass(JWTService);
+    this.bind(RefreshtokenServiceBindings.REFRESHTOKEN_SERVICE).toClass(
+      MyRefreshtokenService,
+    );
 
     // // Bind bcrypt hash services
     this.bind(PasswordHasherBindings.ROUNDS).to(10);

--- a/packages/shopping/src/controllers/specs/user-controller.specs.ts
+++ b/packages/shopping/src/controllers/specs/user-controller.specs.ts
@@ -41,3 +41,22 @@ export const CredentialsRequestBody = {
     'application/json': {schema: CredentialsSchema},
   },
 };
+
+const RefreshTokenSchema = {
+  type: 'object',
+  required: ['refreshToken'],
+  properties: {
+    refreshtoken: {
+      type: 'string',
+      minLength: 8,
+    },
+  },
+};
+
+export const RefreshTokenRequestBody = {
+  description: 'The input of refresh function',
+  required: true,
+  content: {
+    'application/json': {schema: RefreshTokenSchema},
+  },
+};

--- a/packages/shopping/src/controllers/user.controller.ts
+++ b/packages/shopping/src/controllers/user.controller.ts
@@ -63,7 +63,7 @@ export class UserController {
     @inject(TokenServiceBindings.TOKEN_SERVICE)
     public jwtService: TokenService,
     @inject(RefreshtokenServiceBindings.REFRESHTOKEN_SERVICE)
-    public refreshtokenService: RefreshtokenService<User>,
+    public refreshtokenService: RefreshtokenService,
     @inject(UserServiceBindings.USER_SERVICE)
     public userService: UserService<User, Credentials>,
   ) {}
@@ -266,8 +266,8 @@ export class UserController {
     const token = await this.jwtService.generateToken(userProfile);
 
     // create a refreshtoken
-    const refreshtoken = await this.refreshtokenService.generateRefreshtoken(
-      user,
+    const refreshtoken = await this.refreshtokenService.generateToken(
+      userProfile,
     );
 
     return {
@@ -303,7 +303,7 @@ export class UserController {
     @requestBody(RefreshTokenRequestBody) body: {refreshtoken: string},
   ): Promise<{token: string}> {
     // check if the provided refreshtoken is valid, throws error if invalid
-    await this.refreshtokenService.verifyRefreshtoken(
+    await this.refreshtokenService.verifyToken(
       body.refreshtoken,
       currentUserProfile,
     );

--- a/packages/shopping/src/keys.ts
+++ b/packages/shopping/src/keys.ts
@@ -8,6 +8,7 @@ import {PasswordHasher} from './services/hash.password.bcryptjs';
 import {TokenService, UserService} from '@loopback/authentication';
 import {User} from './models';
 import {Credentials} from './repositories';
+import {RefreshtokenService} from './services/refreshtoken.service';
 
 export namespace TokenServiceConstants {
   export const TOKEN_SECRET_VALUE = 'myjwts3cr3t';
@@ -37,4 +38,10 @@ export namespace UserServiceBindings {
   export const USER_SERVICE = BindingKey.create<UserService<User, Credentials>>(
     'services.user.service',
   );
+}
+
+export namespace RefreshtokenServiceBindings {
+  export const REFRESHTOKEN_SERVICE = BindingKey.create<
+    RefreshtokenService<User>
+  >('services.refreshtoken.service');
 }

--- a/packages/shopping/src/keys.ts
+++ b/packages/shopping/src/keys.ts
@@ -41,7 +41,13 @@ export namespace UserServiceBindings {
 }
 
 export namespace RefreshtokenServiceBindings {
-  export const REFRESHTOKEN_SERVICE = BindingKey.create<
-    RefreshtokenService<User>
-  >('services.refreshtoken.service');
+  export const REFRESHTOKEN_ETERNAL_ALLOWED = BindingKey.create<boolean>(
+    'services.refreshtoken.eternal_allowed',
+  );
+  export const REFRESHTOKEN_EXPIRES_IN = BindingKey.create<number>(
+    'services.refreshtoken.expires_in',
+  );
+  export const REFRESHTOKEN_SERVICE = BindingKey.create<RefreshtokenService>(
+    'services.refreshtoken.service',
+  );
 }

--- a/packages/shopping/src/models/index.ts
+++ b/packages/shopping/src/models/index.ts
@@ -8,4 +8,5 @@ export * from './shopping-cart-item.model';
 export * from './shopping-cart.model';
 export * from './order.model';
 export * from './user-credentials.model';
+export * from './user-refreshtoken.model';
 export * from './product.model';

--- a/packages/shopping/src/models/user-refreshtoken.model.ts
+++ b/packages/shopping/src/models/user-refreshtoken.model.ts
@@ -1,0 +1,44 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {Entity, model, property} from '@loopback/repository';
+
+@model()
+export class UserRefreshtoken extends Entity {
+  @property({
+    type: 'string',
+    id: true,
+  })
+  id: string;
+
+  @property({
+    type: 'number',
+    required: true,
+  })
+  ttl: number;
+
+  @property({
+    type: 'date',
+  })
+  creation: Date;
+
+  @property({
+    type: 'string',
+    required: true,
+    mongodb: {dataType: 'ObjectID'},
+  })
+  userId: string;
+
+  constructor(data?: Partial<UserRefreshtoken>) {
+    super(data);
+  }
+}
+
+export interface UserRefreshtokenRelations {
+  // describe navigational properties here
+}
+
+export type UserRefreshtokenWithRelations = UserRefreshtoken &
+  UserRefreshtokenRelations;

--- a/packages/shopping/src/models/user.model.ts
+++ b/packages/shopping/src/models/user.model.ts
@@ -6,6 +6,7 @@
 import {Entity, model, property, hasMany, hasOne} from '@loopback/repository';
 import {Order} from './order.model';
 import {UserCredentials} from './user-credentials.model';
+import {UserRefreshtoken} from './user-refreshtoken.model';
 import {ShoppingCart} from './shopping-cart.model';
 
 @model({
@@ -50,6 +51,9 @@ export class User extends Entity {
 
   @hasOne(() => UserCredentials)
   userCredentials: UserCredentials;
+
+  @hasMany(() => UserRefreshtoken)
+  userRefreshtokens: UserRefreshtoken[];
 
   @hasOne(() => ShoppingCart)
   shoppingCart: ShoppingCart;

--- a/packages/shopping/src/repositories/user-refreshtoken.repository.ts
+++ b/packages/shopping/src/repositories/user-refreshtoken.repository.ts
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: loopback4-example-shopping
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+import {inject} from '@loopback/core';
+import {DefaultCrudRepository, juggler} from '@loopback/repository';
+import {UserRefreshtoken, UserRefreshtokenRelations} from '../models';
+
+export class UserRefreshtokenRepository extends DefaultCrudRepository<
+  UserRefreshtoken,
+  typeof UserRefreshtoken.prototype.id,
+  UserRefreshtokenRelations
+> {
+  constructor(@inject('datasources.mongo') dataSource: juggler.DataSource) {
+    super(UserRefreshtoken, dataSource);
+  }
+}

--- a/packages/shopping/src/repositories/user.repository.ts
+++ b/packages/shopping/src/repositories/user.repository.ts
@@ -10,10 +10,11 @@ import {
   repository,
   HasOneRepositoryFactory,
 } from '@loopback/repository';
-import {User, Order, UserCredentials} from '../models';
+import {User, Order, UserCredentials, UserRefreshtoken} from '../models';
 import {inject, Getter} from '@loopback/core';
 import {OrderRepository} from './order.repository';
 import {UserCredentialsRepository} from './user-credentials.repository';
+import {UserRefreshtokenRepository} from './user-refreshtoken.repository';
 
 export type Credentials = {
   email: string;
@@ -31,6 +32,11 @@ export class UserRepository extends DefaultCrudRepository<
     typeof User.prototype.id
   >;
 
+  public readonly userRefreshtokens: HasManyRepositoryFactory<
+    UserRefreshtoken,
+    typeof User.prototype.id
+  >;
+
   constructor(
     @inject('datasources.mongo') protected datasource: juggler.DataSource,
     @repository(OrderRepository) protected orderRepository: OrderRepository,
@@ -38,11 +44,19 @@ export class UserRepository extends DefaultCrudRepository<
     protected userCredentialsRepositoryGetter: Getter<
       UserCredentialsRepository
     >,
+    @repository.getter('UserRefreshtokenRepository')
+    protected userRefreshtokenRepositoryGetter: Getter<
+      UserRefreshtokenRepository
+    >,
   ) {
     super(User, datasource);
     this.userCredentials = this.createHasOneRepositoryFactoryFor(
       'userCredentials',
       userCredentialsRepositoryGetter,
+    );
+    this.userRefreshtokens = this.createHasManyRepositoryFactoryFor(
+      'userRefreshtokens',
+      userRefreshtokenRepositoryGetter,
     );
     this.orders = this.createHasManyRepositoryFactoryFor(
       'orders',

--- a/packages/shopping/src/services/refreshtoken.service.ts
+++ b/packages/shopping/src/services/refreshtoken.service.ts
@@ -1,0 +1,69 @@
+// Copyright IBM Corp. 2020. All Rights Reserved.
+// Node module: @loopback/authentication
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+import {UserRefreshtokenRepository} from '../repositories/user-refreshtoken.repository';
+import {User} from '../models/user.model';
+import {repository} from '@loopback/repository';
+import {HttpErrors} from '@loopback/rest';
+import {UserProfile, securityId} from '@loopback/security';
+
+export interface RefreshtokenService<U> {
+  generateRefreshtoken(user: User): Promise<string>;
+  verifyRefreshtoken(
+    refreshtoken: string,
+    userProfile: UserProfile,
+  ): Promise<void>;
+  revokeRefreshtoken(
+    refreshtoken: string,
+    userProfile: UserProfile,
+  ): Promise<void>;
+}
+
+export class MyRefreshtokenService implements RefreshtokenService<User> {
+  constructor(
+    @repository(UserRefreshtokenRepository)
+    public userRefreshtokenRepository: UserRefreshtokenRepository,
+  ) {}
+
+  async generateRefreshtoken(user: User): Promise<string> {
+    const userRefreshtoken = await this.userRefreshtokenRepository.create({
+      creation: new Date(),
+      // TODO(derdeka) inject ttl setting
+      ttl: 60 * 60 * 6,
+      userId: user.id,
+    });
+    return userRefreshtoken.id;
+  }
+
+  async verifyRefreshtoken(
+    refreshtoken: string,
+    userProfile: UserProfile,
+  ): Promise<void> {
+    try {
+      // TODO(derdeka) check ttl and creation date
+      await this.userRefreshtokenRepository.findById(refreshtoken, {
+        where: {
+          userId: userProfile[securityId],
+        },
+      });
+    } catch (e) {
+      throw new HttpErrors.Unauthorized('Invalid accessToken');
+    }
+  }
+
+  async revokeRefreshtoken(
+    refreshtoken: string,
+    userProfile: UserProfile,
+  ): Promise<void> {
+    try {
+      await this.userRefreshtokenRepository.deleteById(refreshtoken, {
+        where: {
+          userId: userProfile[securityId],
+        },
+      });
+    } catch (e) {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
Proof of concept for https://github.com/strongloop/loopback-next/issues/4573

Early feedback welcome.

Basic Idea:
- Short-lived `accessToken` (e.g. 10 minutes) and very long-lived `refreshToken` (e.g. 48 hours) which are issued at login time
- the `accessToken` giving access to resources
- the `refreshToken` can be used to to create a new `accessToken`
- the `refreshToken` can be revoked, e.g. by logout