### PR TITLE
ci: pin mongodb version to 4.4 to avoid brew link error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew tap mongodb/brew
-          brew install mongodb-community
-          brew services start mongodb-community
+          brew install mongodb-community@4.4
+          brew services start mongodb-community@4.4
       - name: Start Redis MacOS
         if: matrix.os == 'macos-latest'
         run: |


### PR DESCRIPTION
Github action seems to be usinng Mongodb 4.4 thus installing latest version breaks pipeline. In this PR am pinning the version of Mongodb to 4.4.

Signed-off-by: mrmodise <modisemorebodi@gmail.com>