### PR TITLE
docs: update coc

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,54 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
+
+LoopBack, as member project of the OpenJS Foundation, use
+[Contributor Covenant v2.0](https://contributor-covenant.org/version/2/0/code_of_conduct)
+as their code of conduct. The full text is included
+[below](#contributor-covenant-code-of-conduct-v2.0) in English, and translations
+are available from the Contributor Covenant organisation:
+
+- [contributor-covenant.org/translations](https://www.contributor-covenant.org/translations)
+- [github.com/ContributorCovenant](https://github.com/ContributorCovenant/contributor_covenant/tree/release/content/version/2/0)
+
+Refer to the sections on reporting and escalation in this document for the
+specific emails that can be used to report and escalate issues.
+
+## Reporting
+
+### Project Spaces
+
+For reporting issues in spaces related to LoopBack, please use the email
+`tsc@loopback.io`. The LoopBack Technical Steering Committee (TSC) handles CoC
+issues related to the spaces that it maintains. The project TSC commits to:
+
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in the section on
+  Escalation when required.
+
+### Foundation Spaces
+
+For reporting issues in spaces managed by the OpenJS Foundation, for example,
+repositories within the OpenJS organization, use the email
+`report@lists.openjsf.org`. The Cross Project Council (CPC) is responsible for
+managing these reports and commits to:
+
+- maintain the confidentiality with regard to the reporter of an incident
+- to participate in the path for escalation as outlined in the section on
+  Escalation when required.
+
+## Escalation
+
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a
+foundation-wide team established to manage escalation when a reporter believes
+that a report to a member project or the CPC has not been properly handled. In
+order to escalate to the CoCP send an email to
+`coc-escalation@lists.openjsf.org`.
+
+For more information, refer to the full
+[Code of Conduct governance document](https://github.com/openjs-foundation/cross-project-council/blob/HEAD/CODE_OF_CONDUCT.md).
+
+---
+
+## Contributor Covenant Code of Conduct v2.0
 
 ## Our Pledge
 


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

Update the COC to include OpenJS Foundation escalation path.