### PR TITLE
chore: update GH actions for Node.js version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10, 12, 14, 16, 17]
+        node-version: [14, 16, 17, 18]
         mongodb-version: [4.4]
         redis-version: [6]
         include:


### PR DESCRIPTION
loopback-next modules only support Node.js 14+, so updating the GH actions to reflect what's needed. 

Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>